### PR TITLE
add min/max button & improve slider responsiveness

### DIFF
--- a/frontend/src/components/MainPage.vue
+++ b/frontend/src/components/MainPage.vue
@@ -10,6 +10,7 @@
         <MenuView
           @newRequest="processNewRequest"
           @isMinOfSliderHasChanged="changeSlidersIsMinState"
+          @clearMap="processNewRequest"
           :sliders="sliders"
         />
       </v-col>

--- a/frontend/src/components/MenuView.vue
+++ b/frontend/src/components/MenuView.vue
@@ -219,6 +219,7 @@ export default {
           }
         }
       }
+      this.doRequest();
     },
     /**
      * Removes a layer with a given name
@@ -228,6 +229,11 @@ export default {
         if (this.activeSliders[j] == name) {
           this.activeSliders.splice(j, 1);
         }
+      }
+      if (this.activeSliders.length != 0) {
+        this.doRequest();
+      } else {
+        this.clearMap();
       }
     },
     // returns a string in the following form:
@@ -287,6 +293,7 @@ export default {
         }
       }
       this.removeNotActiveLayers();
+      this.doRequest();
     },
     /**
      * Removes all layers that are currently not active
@@ -316,6 +323,9 @@ export default {
 
       // sends an event, that the parent component (in this case Mainpage) can listen to
       this.$emit("newRequest", this.response);
+    },
+    async clearMap() {
+      this.$emit("clearMap", null);
     },
   },
   mounted() {


### PR DESCRIPTION
A min/max button is now added to the menu. To enable a feasible look which doesn't limit the slider usability, a few design changes were made that may need to be discussed. As for now, the slider component looks like this:
![image](https://user-images.githubusercontent.com/46593824/207737932-b972583c-9a4e-41fe-bbec-2ae6956d4d1e.png)

The design is full on responsive and all buttons above the slider remain visible in one line, no matter the device size. The slider was moved to a separate row. This allows a trouble-free usage of it. Before, the slider was sometimes not usable anymore. That doesn't happen anymore.
There are still a few improvements to be made, which will be added to the kanban board: e.g. do request when the backend is adjusted, add tooltip for min/max button, make name and value buttons unclickable
