### PR TITLE
Add and remove marker on right click and center marker on left click

### DIFF
--- a/frontend/src/components/MapView.vue
+++ b/frontend/src/components/MapView.vue
@@ -91,6 +91,21 @@ export default {
           position: "topright",
         })
         .addTo(this.map);
+
+      this.map.addEventListener('contextmenu', (event) => {
+        const options = {
+          opacity: 0.9,
+          riseOnHover: true
+        };
+        const marker = L.marker(event.latlng, options).addTo(this.map);
+        marker.addEventListener('click', (event) => {
+          this.map.panTo(event.latlng);
+        })
+        marker.addEventListener('contextmenu', () => {
+          marker.remove(this.map)
+        });
+      });
+
     },
     changeGeojson: function (newGeojson) {
       this.resultJson = JSON.parse(JSON.stringify(newGeojson));


### PR DESCRIPTION
I implemented a basic feature that allows to place a marker on the map with a right click and remove it in the same way. Left-clicking on a marker centers the map view on it.
Maybe later we can add a proper context menu, but it's not trivial and I skipped it for now.