### PR TITLE
Changed the marker clustering

### DIFF
--- a/frontend/src/components/MapView.vue
+++ b/frontend/src/components/MapView.vue
@@ -322,6 +322,7 @@ export default {
       });
 
       this.busLayerMarkerCluster = L.markerClusterGroup.layerSupport({
+        showCoverageOnHover: false,
         polygonOptions: {
           fillColor: "#245fb3", // polygon color
           color: "#245fb3", // line color


### PR DESCRIPTION
removed the "show coverage" for marker clustering
<img width="418" alt="Bildschirm­foto 2023-01-25 um 14 43 51" src="https://user-images.githubusercontent.com/61976072/214579128-ec13be33-a4c6-4658-bfdb-8707e8fcfee2.png">
